### PR TITLE
Update style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -294,3 +294,8 @@ Text Domain: planet4-child-theme-hungary
 .accordion-text {
   padding-top:1em;
 }
+
+/*Change font size below 500px*/
+@media only screen and (max-width: 500px) {
+  .gphu-smaller-headline-below-500px h2{font-size:2em;}
+}


### PR DESCRIPTION
Decrease h2 headline size below 500px screen width on certain pages, to avoid word break in long words.